### PR TITLE
Troubleshoot with PBID on the gateway computer

### DIFF
--- a/data-integration/gateway/service-gateway-tshoot.md
+++ b/data-integration/gateway/service-gateway-tshoot.md
@@ -131,8 +131,8 @@ To troubleshoot a data source issue, use Power BI Desktop locally on the gateway
 This test is especially helpful if the data source requires additional components to be installed on the computer, such as a third-party database driver. Also, a local test helps to test data source connections that require additional environment settings, such as access to a shared network drive file or folder.
 This technique allows you to test iteratively, testing the connection on the gateway computer after each configuration change.
 
-Although it is not a guarantee of a successful refresh through the gateway, a successful Power BI Desktop refresh from the gateway computer is a strong indicator that everything is configured correctly on the gateway computer.
-In other words, if you cannot refresh in Power BI Desktop from the gateway computer, it is highly unlikely that a refresh through the gateway will succeed.
+Although it isn't a guarantee of a successful refresh through the gateway, a successful Power BI Desktop refresh from the gateway computer is a strong indicator that everything is configured correctly on the gateway computer.
+In other words, if you can't refresh in Power BI Desktop from the gateway computer, it's highly unlikely that a refresh through the gateway will succeed.
 After a successful refresh in Desktop, you can narrow your troubleshooting steps to the configuration of the datasource and the dataset in the Power BI Service.
 
 ## Limitations and considerations

--- a/data-integration/gateway/service-gateway-tshoot.md
+++ b/data-integration/gateway/service-gateway-tshoot.md
@@ -124,7 +124,7 @@ To find the event logs for the *on-premises data gateway service*, follow these 
 
 ![On-premises data gateway event logs.](media/service-gateway-tshoot/on-prem-data-gateway-event-logs.png)
 
-## Troubleshooting refresh failures for a specific source
+## Troubleshoot refresh failures for a specific source
 
 Refreshes utilizing the gateway require that the source be accessible from the computer with the gateway installation.
 As such, when troubleshooting a data source, especially one that requires additional components to be installed on the computer (such as a third party database driver) or additional configuration (such as access to a network drive file or folder), it can be helpful to troubleshoot with Power BI Desktop from the gateway computer.

--- a/data-integration/gateway/service-gateway-tshoot.md
+++ b/data-integration/gateway/service-gateway-tshoot.md
@@ -124,6 +124,16 @@ To find the event logs for the *on-premises data gateway service*, follow these 
 
 ![On-premises data gateway event logs.](media/service-gateway-tshoot/on-prem-data-gateway-event-logs.png)
 
+## Troubleshooting refresh failures for a specific source
+
+Refreshes utilizing the gateway require that the source be accessible from the computer with the gateway installation.
+As such, when troubleshooting a data source, especially one that requires additional components to be installed on the computer (such as a third party database driver) or additional configuration (such as access to a network drive file or folder), it can be helpful to troubleshoot with Power BI Desktop from the gateway computer.
+Using Power BI Desktop on the gateway computer allows for more rapid iterations of testing the connection and configuring any requirements on the gateway computer directly.
+
+Although it is not a guarantee of a successful refresh through the gateway, a successful Power BI Desktop refresh from the gateway computer is a strong indicator that everything is configured correctly on the gateway computer.
+In other words, if you cannot refresh in Power BI Desktop from the gateway computer, it is highly unlikely that a refresh through the gateway will succeed.
+After a successful refresh in Desktop, you can narrow your troubleshooting steps to the configuration of the datasource and the dataset in the Power BI Service.
+
 ## Limitations and considerations
 
 The Power BI [gateways REST APIs](/rest/api/power-bi/gateways) don't support [gateway clusters](service-gateway-high-availability-clusters.md).

--- a/data-integration/gateway/service-gateway-tshoot.md
+++ b/data-integration/gateway/service-gateway-tshoot.md
@@ -127,7 +127,8 @@ To find the event logs for the *on-premises data gateway service*, follow these 
 ## Troubleshoot refresh failures for a specific source
 
 Refreshes utilizing the gateway require that the source be accessible from the computer with the gateway installation.
-As such, when troubleshooting a data source, especially one that requires additional components to be installed on the computer (such as a third party database driver) or additional configuration (such as access to a network drive file or folder), it can be helpful to troubleshoot with Power BI Desktop from the gateway computer.
+To troubleshoot a data source issue, use Power BI Desktop locally on the gateway computer to test the connection.
+This test is especially helpful if the data source requires additional components to be installed on the computer, such as a third-party database driver. Also, a local test helps to test data source connections that require additional environment settings, such as access to a shared network drive file or folder.
 This technique allows you to test iteratively, testing the connection on the gateway computer after each configuration change.
 
 Although it is not a guarantee of a successful refresh through the gateway, a successful Power BI Desktop refresh from the gateway computer is a strong indicator that everything is configured correctly on the gateway computer.

--- a/data-integration/gateway/service-gateway-tshoot.md
+++ b/data-integration/gateway/service-gateway-tshoot.md
@@ -128,7 +128,7 @@ To find the event logs for the *on-premises data gateway service*, follow these 
 
 Refreshes utilizing the gateway require that the source be accessible from the computer with the gateway installation.
 As such, when troubleshooting a data source, especially one that requires additional components to be installed on the computer (such as a third party database driver) or additional configuration (such as access to a network drive file or folder), it can be helpful to troubleshoot with Power BI Desktop from the gateway computer.
-Using Power BI Desktop on the gateway computer allows for more rapid iterations of testing the connection and configuring any requirements on the gateway computer directly.
+This technique allows you to test iteratively, testing the connection on the gateway computer after each configuration change.
 
 Although it is not a guarantee of a successful refresh through the gateway, a successful Power BI Desktop refresh from the gateway computer is a strong indicator that everything is configured correctly on the gateway computer.
 In other words, if you cannot refresh in Power BI Desktop from the gateway computer, it is highly unlikely that a refresh through the gateway will succeed.


### PR DESCRIPTION
It can often be useful to troubleshoot source connectivity issues for a gateway by installing Power BI Desktop on the gateway computer and testing connectivity there.

Add a brief description of this troubleshooting technique.

I recommend this often to clients and those asking for help with gateway connections, and it is usually a helpful troubleshooting step.