### PR TITLE
Update Gateway requirements

### DIFF
--- a/data-integration/gateway/service-gateway-install.md
+++ b/data-integration/gateway/service-gateway-install.md
@@ -17,9 +17,8 @@ In this article, we show you how to install a standard gateway, how to add anoth
 
 ### Minimum requirements
 
-* .NET Framework 4.7.2 (Gateway release December 2020 and earlier)
-* .NET Framework 4.8 (Gateway release February 2021 and later)
-* A 64-bit version of Windows 10 or a 64-bit version of Windows Server 2012 R2 with [current TLS 1.2 and cipher suites](/power-platform/admin/onpremises-server-cipher-tls-requirements)
+* .NET Framework 4.8
+* A 64-bit version of Windows 10 or a 64-bit version of Windows Server 2016
 * 4-GB disk space for [performance monitoring](service-gateway-performance.md#gateway-performance-monitoring-public-preview) logs (in default configuration)
 
 > [!NOTE]
@@ -29,7 +28,7 @@ In this article, we show you how to install a standard gateway, how to add anoth
 
 * An 8-core CPU
 * 8 GB of memory
-* A 64-bit version of Windows Server 2012 R2 or later
+* A 64-bit version of Windows Server 2016 or later
 * Solid-state drive (SSD) storage for spooling
 
 ### Related considerations


### PR DESCRIPTION
- 2012 R2 is out of support - https://learn.microsoft.com/en-us/lifecycle/announcements/windows-server-2012-r2-end-of-support
- "Beginning with Windows 10, version 1607 and Windows Server 2016, the TLS client and server SSL 3.0 is disabled by default." https://learn.microsoft.com/en-us/windows-server/security/tls/tls-schannel-ssp-changes-in-windows-10-and-windows-server