### PR TITLE
fix: Typo on vnet overview page (reccomend)

### DIFF
--- a/data-integration/vnet/overview.md
+++ b/data-integration/vnet/overview.md
@@ -15,7 +15,7 @@ The virtual network data gateway lets you connect your Azure and other data serv
 
 - Currently, this feature is available only for Fabric Dataflow Gen2, Power BI semantic models, Power Platform dataflows, and Power BI paginated reports. Power BI dataflows and datamarts are not supported.
 
-- VNet data gateway is currently available for P, F, and A4 or above (A4, A5, A6, and A7) SKUs. For F SKUs we reccomend that you use F8 and above but all F SKUs will work.
+- VNet data gateway is currently available for P, F, and A4 or above (A4, A5, A6, and A7) SKUs. For F SKUs we recommend that you use F8 and above but all F SKUs will work.
 
 - This feature is currently not supported in GCC L2. We do support GCC L4 (Texas and Virginia) and L5 (DoD East). We support air gapped clouds in US Nat East/West and US Sec East/West.
 


### PR DESCRIPTION
Fixed type on the VNet data gateway overview page. The word `reccomend` has a typo and should be `recommend`.